### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.vscode
+*.sw[po]
+local
+extlib
+


### PR DESCRIPTION
取り急ぎ、モジュールを手元に cpanmとかで入れて試したいとき用と、vscodeとvimのファイル避ける用です。