### PR TITLE
Format correction in RFC0008

### DIFF
--- a/docs/articles/github.com/Perl/RFCs/rfcs/rfc0008.md
+++ b/docs/articles/github.com/Perl/RFCs/rfcs/rfc0008.md
@@ -18,6 +18,7 @@
     Status:  Implemented
 
 ## Abstract 概要
+
 標準的(定義済みで参照されていない)スカラーに、それにブーリアン値を表すかを追跡する機能を
 追加します。　`$x == $y` などのブーリアンの式から作成された値は、後で参照された場合でも確認できる方法で変数に格納されます。
 
@@ -26,6 +27,7 @@ Add to regular (defined and non-referential) scalars the ability to track whethe
 -->
 
 ## Motivation モチベーション
+
 言語の相互運用性の問題から文字列や数値などの型データの区別して表現することが
 必要になる場合がある。Perlの他の場所でも、この区別を追加する試みがなされています。
 このRFCでは trueやfalseと言った真偽値の扱い方を表現することを検討する。
@@ -53,6 +55,7 @@ $ nodejs -e 'console.log(JSON.stringify([1, "1", 1 == 1]))'
 $ perl -MJSON::MaybeUTF8=encode_json_utf8 -E 'say encode_json_utf8([1, "1", 1 == 1])'
 [1,"1",1]
 ```
+
 `JSON::PP::Boolean` のようなワークアラウンドで不足を補充するようなモジュールの傾向があります。
 
 <!-- original
@@ -75,6 +78,7 @@ Obviously such a solution is specific to JSON encoding and does not apply to, fo
 -->
 
 TODO: シリアライゼーションに依存しない純粋なインコア処理についてもいくつかコメントの追加
+
 <!-- original
 ((TODO: Add some comments about purely in-core handling as well that don't rely on serialisation))
 -->
@@ -82,6 +86,7 @@ TODO: シリアライゼーションに依存しない純粋なインコア処�
 ## Rationale 合理的な理由
 
 ## Specification 仕様
+
 この仕様には、XSコードから見えるCコード実装の低レベルのインコアディテールと、Perlプログラムから見える高レベルのPerlビジブルディテールの2つのパートがあります。
 
 <!-- original
@@ -89,6 +94,7 @@ There are two parts to this specification; the lower-level in-core details of th
 -->
 
 ### C-level Internals C言語の内部
+
 Cレベルで、SVが真偽値を含むかどうかをテストするマクロが必要になります。
 
 <!-- original
@@ -121,7 +127,7 @@ It may be possible to find a spare `SvFLAGS` field for this purpose, at which po
 -->
 
 フラグビットは希少で高価なため、予備のフラグビットを見つけるのは不可能（少なくとも望まない）かもしれません。
-これは、そのような boolean の `SvPVX()` スロットに特別なポインタ値を使用することで、代わりに実装することができます。sv_setsv()` とその仲間に小さな変更を加えて、実際のポインタ値そのものをコピーするようにすれば、任意の "boolean" SV を、このフィールドのポインタの等価性によって区別できるようになり、オリジナルの "yes" と "no" 不死身のものと同じにすることが可能になるでしょう。
+これは、そのような boolean の `SvPVX()` スロットに特別なポインタ値を使用することで、代わりに実装することができます。`sv_setsv()` とその仲間に小さな変更を加えて、実際のポインタ値そのものをコピーするようにすれば、任意の "boolean" SV を、このフィールドのポインタの等価性によって区別できるようになり、オリジナルの "yes" と "no" 不死身のものと同じにすることが可能になるでしょう。
 
 <!-- original
 Flag bits being rare and expensive, it may turn out that finding a spare flag bit is simply impossible (or at least, undesired). This could be implemented instead by using special pointer values in the `SvPVX()` slots of such booleans. A small change to `sv_setsv()` and friends would be possible to cause it to copy the actual pointer value itself, such that any "boolean" SV can be distinguished by pointer equality of this field, to that of the original "yes" and "no" immortals.
@@ -129,6 +135,7 @@ Flag bits being rare and expensive, it may turn out that finding a spare flag bi
 
 
 ### Perl-level Interface Perlのインターフェース
+
 インタープリタが "is a boolean"の概念を確実に保存し、少なくともXSモジュールがこれを公開できるようになれば、pureperlのコードがどのように利用できるかという疑問が残ります。どうやって真偽値を作り出し、
 どうやってその値が真偽値で与えられているかをテストするのでしょうか？
 
@@ -138,6 +145,7 @@ Once the interpreter can reliably store the concept of "is a boolean" and expose
 
 それらの値を生成するために、いくつかのケースでは既存の真偽値の述語演算子を単純に
 利用することで十分である。例えば、比較演算子である。
+
 <!-- original
 For creating such values, in many cases it is sufficient to simply use any of the existing boolean predicate operators, for example the comparison operators:
 -->
@@ -145,6 +153,7 @@ For creating such values, in many cases it is sufficient to simply use any of th
 ```perl
 my $sv = 4 > 5;  $svはSvIsBOOLを持っている
 ```
+
 <!-- original
 # The $sv now has SvIsBOOL 
 -->
@@ -167,11 +176,12 @@ func(0, "0", "", false);  # 4つの異なる値
 
 <!-- original
 # Three distinct values
- # Four distinct values
+# Four distinct values
 -->
 
 問題は、pureperlのコードがどのようにして値の「型」を検査し、それがこの特別なブーリアン値の1つであるかどうかを検査できるのかということです。perl coreには
 このためのテストキーワードはありませんが、現在利用可能な機能に最も近いのは、新しい組み込み関数を追加することです。
+
 <!-- original
 The question remains on how pureperl code can inspect the "type" of a value to inspect if it is one of these special boolean values. While perl core doesn't have any testing keywords for this, the nearest match to currently available features may be to add a new builtin function:
 -->
@@ -300,6 +310,7 @@ One thing that is certainly impossible to do currently is change the stringifica
 ```perl
 is( somefunc(), "", 'somefunc returns false' );
 ```
+
 ## Open Issues 
 
 ## Copyright


### PR DESCRIPTION
perldoc.jpに途中までしか表示されていなかったのでフォーマットの修正とシングルクォーテーションの漏れがあったので修正