### PR TITLE
Rename RFC to PPC

### DIFF
--- a/docs/articles/github.com/Perl/PPCs/README.md
+++ b/docs/articles/github.com/Perl/PPCs/README.md
@@ -1,18 +1,19 @@
-# Perl/RFCs/README の翻訳
+# Perl/PPCs/README の翻訳
 
-この文書は、[Perl/RFCs/README](https://github.com/Perl/RFCs/blob/main/README.md)を翻訳したものです。
+この文書は、[Perl/PPCs/README](https://github.com/Perl/PPCs/blob/main/README.md)を翻訳したものです。
 
 <!-- original
 This repository is for *Requests For Comments* - proposals to change the Perl language.
+This repository is for *Proposed Perl Changes* - proposals to change the Perl language.
 -->
 
-このリポジトリは、**リクエスト・フォー・コメンツ**です。 - Perl言語を変更するための提案
+このリポジトリは、**Perlの変更提案(Proposed Perl Changes)**です。 - Perl言語を変更するための提案
 
 <!-- original
 Right now, we're [trialling the process](docs/process.md). If you would like to submit a feature request, please [email an *elevator pitch*](mailto:perl5-porters@perl.org) - a short message with 4 paragraphs:
 -->
 
-現在、私たちは[このプロセスを試しています](https://github.com/Perl/RFCs/blob/main/docs/process.md)。機能要求を送る場合は、次の4項目を簡潔にまとめた[エレベーターピッチをメール](mailto:perl5-porters@perl.org)してください。
+現在、私たちは[このプロセスを試しています](https://github.com/Perl/PPCs/blob/main/docs/process.md)。機能要求を送る場合は、次の4項目を簡潔にまとめた[エレベーターピッチをメール](mailto:perl5-porters@perl.org)してください。
 
 <!-- original
 1. Here is a problem
@@ -40,14 +41,14 @@ That will be enough to make it obvious whether the idea is
 
 <!-- original
 0) actually a **bug** - a change we'd also consider back porting to maintenance releases (so should be a opened as [*Report a Perl 5 bug*](https://github.com/Perl/perl5/issues/new/choose))
-0) worth drafting an RFC for
+0) worth drafting an PPC for
 0) better on CPAN first
 0) "nothing stops you putting it on CPAN, but it doesn't seem viable"
 -->
 
 
 * 0) 実際に**バグ**である - メンテナンスリリースへの変更も考慮すべき変更（そのため、*[Report a Perl 5 bug*](https://github.com/Perl/perl5/issues/new/choose)のようにオープンであるべき）
-* 0) RFCを作成する価値がある
+* 0) PPCを作成する価値がある
 * 0) まずCPANに置いた方が良い
 * 0) "CPANに置くことを止められないが、実現できるとは思えない"
 
@@ -67,21 +68,21 @@ Please **don't** submit ideas as *issues* or *PRs* on this repository. (We can d
 These files describe the process we are trialling
 -->
 
-次のファイルには、試験中のこのRFCsのプロセスについて記載しています。
+次のファイルには、試験中のこのPPCsのプロセスについて記載しています。
 
 <!-- original
 * [motivation.md](docs/motivation.md) - why do we want to do something
 * [process.md](docs/process.md) - the initial version of the process
-* [template.md](docs/template.md) - the RFC template
+* [template.md](docs/template.md) - the PPC template
 * [future.md](docs/future.md) - how we see the process evolving
 * [others.md](docs/others.md) - what others do (or did), and what we can learn from them
 -->
 
-* [motivation.md](https://github.com/Perl/RFCs/blob/main/docs/motivation.md) - 何がしたいのか
-* [process.md](https://github.com/Perl/RFCs/blob/main/docs/process.md) - このプロセスの初期バージョン
-* [template.md](https://github.com/Perl/RFCs/blob/main/docs/template.md) - このRFCのテンプレート
-* [future.md](https://github.com/Perl/RFCs/blob/main/docs/future.md) - このプロセスの今後のイメージ
-* [others.md](https://github.com/Perl/RFCs/blob/main/docs/others.md) - what others do (or did), and what we can learn from them
+* [motivation.md](https://github.com/Perl/PPCs/blob/main/docs/motivation.md) - 何がしたいのか
+* [process.md](https://github.com/Perl/PPCs/blob/main/docs/process.md) - このプロセスの初期バージョン
+* [template.md](https://github.com/Perl/PPCs/blob/main/docs/template.md) - このPPCのテンプレート
+* [future.md](https://github.com/Perl/PPCs/blob/main/docs/future.md) - このプロセスの今後のイメージ
+* [others.md](https://github.com/Perl/PPCs/blob/main/docs/others.md) - what others do (or did), and what we can learn from them
 
 <!-- original
 ## The Tracker
@@ -90,10 +91,10 @@ These files describe the process we are trialling
 ## トラッカー
 
 <!-- original
-The status of proposals is tracked in "[the RFC
+The status of proposals is tracked in "[the PPC
 Tracker](https://docs.google.com/spreadsheets/d/1hVOS7ePuLbVkYcf5S-e_eAodj4izm9Cj7AVs25HvngI)",
 a Google Sheets spreadsheet.  Keep up to date there!
 -->
 
-提案のステータスは、次のスプレッドシートで追跡できます。[the RFC
+提案のステータスは、次のスプレッドシートで追跡できます。[the PPC
 Tracker](https://docs.google.com/spreadsheets/d/1hVOS7ePuLbVkYcf5S-e_eAodj4izm9Cj7AVs25HvngI) ここで最新の情報を入手しましょう！

--- a/docs/articles/github.com/Perl/PPCs/ppcs/ppc0001-n-at-a-time-for.md
+++ b/docs/articles/github.com/Perl/PPCs/ppcs/ppc0001-n-at-a-time-for.md
@@ -1,6 +1,6 @@
-# Perl/RFCs/rfcs/rfc0001 N-at-a-time with for　の翻訳
+# Perl/PPCs/ppcs/ppc0001 N-at-a-time with for　の翻訳
 
-この文書は、[Perl/RFCs/rfcs/rfc0001](https://github.com/Perl/RFCs/blob/main/rfcs/rfc0001.md)を翻訳したものです。
+この文書は、[Perl/PPCs/ppcs/ppc0001-n-at-a-time-for](https://github.com/Perl/PPCs/blob/main/ppcs/ppc0001-n-at-a-time-for.md)を翻訳したものです。
 
 原題は、「Multiple-alias syntax for foreach」です
 

--- a/docs/articles/github.com/Perl/PPCs/ppcs/ppc0008-sv-boolean-type.md
+++ b/docs/articles/github.com/Perl/PPCs/ppcs/ppc0008-sv-boolean-type.md
@@ -1,6 +1,6 @@
-# Perl/RFCs/rfcs/rfc0008  Stable SV Boolean Typeの翻訳
+# Perl/PPCs/ppcs/ppc0008  Stable SV Boolean Typeの翻訳
 
-この文書は、[Perl/RFCs/rfcs/rfc0008](https://github.com/Perl/RFCs/blob/main/rfcs/rfc0008.md)を翻訳したものです。
+この文書は、[Perl/PPCs/ppcs/ppc0008-sv-boolean-type](https://github.com/Perl/PPCs/blob/main/ppcs/ppc0008-sv-boolean-type.md)を翻訳したものです。
 
 原題は「Stable SV Boolean Type」です。
 
@@ -30,11 +30,11 @@ Add to regular (defined and non-referential) scalars the ability to track whethe
 
 言語の相互運用性の問題から文字列や数値などの型データの区別して表現することが
 必要になる場合がある。Perlの他の場所でも、この区別を追加する試みがなされています。
-このRFCでは trueやfalseと言った真偽値の扱い方を表現することを検討する。
+このPPCでは trueやfalseと言った真偽値の扱い方を表現することを検討する。
 
 
 <!-- original
-Language interoperability concerns sometimes lead to situations where it is necessary to represent typed data - such as strings or numbers - in a way that can be reliably distinguished. Elsewhere in Perl there are attempts to add this distinction. This RFC attempts to address how to handle values of a boolean type; values that represent a simple true-or-false nature.
+Language interoperability concerns sometimes lead to situations where it is necessary to represent typed data - such as strings or numbers - in a way that can be reliably distinguished. Elsewhere in Perl there are attempts to add this distinction. This PPC attempts to address how to handle values of a boolean type; values that represent a simple true-or-false nature.
 -->
 
 例えばJSONやMsgPackなどの一般に使用されるシリアル化形式は、Perlでも生成やパースが可能です。
@@ -161,10 +161,10 @@ my $sv = 4 > 5;  $svはSvIsBOOLを持っている
 
 これらの値を明示的に作成するために、 `true` と `false` の2つの新しいゼロ個性関数を提供することは
 有用であると考えられるでしょう。( 少なくとも同等の `!!1` や `!!0` よりも少しは意図が
-明らかです ) これらは `builtin` モジュール (RFC 0009) から要求することができます。
+明らかです ) これらは `builtin` モジュール (PPC 0009) から要求することができます。
 
 <!-- original
-It may be considered useful to provide two new zero-arity functions, `true` and `false`, to explicitly create these values (which are at least a little more obvious in intent than the equivalent `!!1` and `!!0`). These can be requested from the `builtin` module (RFC 0009):
+It may be considered useful to provide two new zero-arity functions, `true` and `false`, to explicitly create these values (which are at least a little more obvious in intent than the equivalent `!!1` and `!!0`). These can be requested from the `builtin` module (PPC 0009):
 -->
 
 ```perl
@@ -221,10 +221,10 @@ I accept that this is the weakest part of this suggestion so far, and welcome co
 There are not expected to be any backwards compatiblity problems with this proposal. At the interpreter level, extra information is being added to certain SV values, without changing the meaning of any existing information currently stored. Code that is unaware of the new semantics will continue to see existing values unaltered.
 -->
 
-同様にPerlの構文レベルでも、新たに追加される機能は`builtin`名前空間の新関数だけです。（RFC 0009）。
+同様にPerlの構文レベルでも、新たに追加される機能は`builtin`名前空間の新関数だけです。（PPC 0009）。
 
 <!-- original
-Likewise at the Perl syntax level, the only new functionality being added consists of new functions in the `builtin` namespace (RFC 0009).
+Likewise at the Perl syntax level, the only new functionality being added consists of new functions in the `builtin` namespace (PPC 0009).
 -->
 
 ## Security Implications セキュリティの意味合い

--- a/docs/articles/github.com/Perl/PPCs/ppcs/ppc0009-builtin-namespace.md
+++ b/docs/articles/github.com/Perl/PPCs/ppcs/ppc0009-builtin-namespace.md
@@ -1,6 +1,6 @@
-# Perl/RFCs/rfcs/rfc0009 Namespace for Builtin Functions の翻訳
+# Perl/PPCs/ppcs/ppc0009 Namespace for Builtin Functions の翻訳
 
-この文書は、[Perl/RFCs/rfcs/rfc0009](https://github.com/Perl/RFCs/blob/main/rfcs/rfc0009.md)を翻訳したものです。
+この文書は、[Perl/PPCs/ppcs/ppc0009-builtin-namespace](https://github.com/Perl/PPCs/blob/main/ppcs/ppc0009-builtin-namespace.md)を翻訳したものです。
 
 原題は「Namespace for Builtin Functions」です。
 
@@ -60,11 +60,11 @@ or
     say "The reference type of ref is ", builtin::reftype($ref);
 
 
-**Note:** この提案の主な関心ごとは、これらの関数を提供する全体的な**仕組み**です。提供されるべき全ての関数の詳細な一覧の提案はしません。まずは、アイデア全体を試すために、いくつかの有力な候補の関数から始めます。安定が確かめられれば、ケースバイケースで関数の追加を検討します。RFCのプロセスを利用するかどうかは、ケースによります。いずれにせよ、言語が進化するにつれ、この関数の一覧が継続的にメンテナンスされ、リリースごとに関数が追加されることを期待しています。
+**Note:** この提案の主な関心ごとは、これらの関数を提供する全体的な**仕組み**です。提供されるべき全ての関数の詳細な一覧の提案はしません。まずは、アイデア全体を試すために、いくつかの有力な候補の関数から始めます。安定が確かめられれば、ケースバイケースで関数の追加を検討します。PPCのプロセスを利用するかどうかは、ケースによります。いずれにせよ、言語が進化するにつれ、この関数の一覧が継続的にメンテナンスされ、リリースごとに関数が追加されることを期待しています。
 
 
 <!-- original
-**Note:** This proposal largely concerns itself with the overal *mechanism* used to provide these functions, and expressly does not go into a full detailed list of individual proposed functions that ought to be provided. A short list is given containing a few likely candidates to start with, in order to experiment with the overall idea. Once found stable, it is expected that more functions can be added on a case-by-case basis; perhaps by using the RFC process or not, as individual cases require. In any case, it is anticipated that this list would be maintained on an ongoing basis as the language continues to evolve, with more functions being added at every release.
+**Note:** This proposal largely concerns itself with the overal *mechanism* used to provide these functions, and expressly does not go into a full detailed list of individual proposed functions that ought to be provided. A short list is given containing a few likely candidates to start with, in order to experiment with the overall idea. Once found stable, it is expected that more functions can be added on a case-by-case basis; perhaps by using the PPC process or not, as individual cases require. In any case, it is anticipated that this list would be maintained on an ongoing basis as the language continues to evolve, with more functions being added at every release.
 -->
 
 ## Rationale
@@ -264,10 +264,10 @@ As this proposal does not go into a full list of what specific functions might b
 * Some of the `POSIX` functions that act abstractly as in-memory data utilities, such as `ceil` and `floor`. I would not recommend adding the bulk of the operating system interaction functions from POSIX.
 -->
 
-* 新しい名前付き関数を提案するような他のRFCやPre-RFCの議論は、このモジュールの良い候補になると思います。このRFCを参照しながら、提案のメリットを検討できます。この文書を書いた時点では、コアサポートのboolean型(RFC 0008)や新たなモジュールローディング関数(RFC 0006)が候補になりそうです。
+* 新しい名前付き関数を提案するような他のPPCやPre-PPCの議論は、このモジュールの良い候補になると思います。このPPCを参照しながら、提案のメリットを検討できます。この文書を書いた時点では、コアサポートのboolean型(PPC 0008)や新たなモジュールローディング関数(PPC 0006)が候補になりそうです。
 
 <!-- original
-* There are other RFCs or Pre-RFC discussions that suggest adding new named functions that would be good candidates for this module. They can be considered on their own merit, by reference to this RFC. At time of writing this may include new functions to handle core-supported boolean types (RFC 0008) or the new module-loading function (RFC 0006).
+* There are other PPCs or Pre-PPC discussions that suggest adding new named functions that would be good candidates for this module. They can be considered on their own merit, by reference to this PPC. At time of writing this may include new functions to handle core-supported boolean types (PPC 0008) or the new module-loading function (PPC 0006).
 -->
 
 * 関数の安定したセットが定まったら、`feature.pm`と同様にバージョン番号つきのバンドルを検討してください。
@@ -356,16 +356,16 @@ This does initially seem attractive, until one considers the possibility that a 
 
 ### Polyfill for Unavailable Semantics
 
-新しいperlにどのように組み込み関数を提供するかという問題とは直接関係ありませんが、古いperl向けのポリフィルがデュアルライフのCPANモジュールとして提供されいて、もし古いperlが提供された関数のセマンティックをサポートできないとき、どうすべきかという問題が出てきます。現在の提案のように`Scalar::Util`のような既存のコードからコピーしてくる場合は、この問題を引き起こしませんが、追加されるいくつかのRFCを検討した場合、より複雑なエッジケースに遭遇します。
+新しいperlにどのように組み込み関数を提供するかという問題とは直接関係ありませんが、古いperl向けのポリフィルがデュアルライフのCPANモジュールとして提供されいて、もし古いperlが提供された関数のセマンティックをサポートできないとき、どうすべきかという問題が出てきます。現在の提案のように`Scalar::Util`のような既存のコードからコピーしてくる場合は、この問題を引き起こしませんが、追加されるいくつかのPPCを検討した場合、より複雑なエッジケースに遭遇します。
 
 <!-- original
-While not directly related to the question of how to provide builtin functions to new perls, by offering to provide a dual-life module on CPAN as a polyfill for older perl releases, the question arises on what to do if older perls cannot support the semantics of a provided function. The current suggestion of copying existing functions out of places like `Scalar::Util` does not cause this problem, but when we consider some of the additional RFCs we run into some more complex edge-cases.
+While not directly related to the question of how to provide builtin functions to new perls, by offering to provide a dual-life module on CPAN as a polyfill for older perl releases, the question arises on what to do if older perls cannot support the semantics of a provided function. The current suggestion of copying existing functions out of places like `Scalar::Util` does not cause this problem, but when we consider some of the additional PPCs we run into some more complex edge-cases.
 -->
 
-例えば、RFC 0008では、`true`や`false`といった言語レベルの真偽値を返す新たな関数の追加と、`isbool`という与えられた値が真偽値であるか判定する関数を提案しています。古いperlに対して、最初の2つの関数を提供することは簡単ですが、後者はポリフィルすることはできません。なぜなら、古いperlでは、"これが真偽値か？"という問いに意味がないからです。こういった状況を処理する方法はいくつかあります。
+例えば、PPC 0008では、`true`や`false`といった言語レベルの真偽値を返す新たな関数の追加と、`isbool`という与えられた値が真偽値であるか判定する関数を提案しています。古いperlに対して、最初の2つの関数を提供することは簡単ですが、後者はポリフィルすることはできません。なぜなら、古いperlでは、"これが真偽値か？"という問いに意味がないからです。こういった状況を処理する方法はいくつかあります。
 
 <!-- original
-For example, RFC 0008 proposes adding new functions `true` and `false` to provide real language-level boolean values, and an `isbool` predicate function to enquire whether a given value has boolean intention. The first two can be easily provided on older perls, but polyfilling this latter function is not possible, because the question of "does this value have boolean intention?" is not a meaningful question to ask on such perls. There are a number of possible ways to handle this situation:
+For example, PPC 0008 proposes adding new functions `true` and `false` to provide real language-level boolean values, and an `isbool` predicate function to enquire whether a given value has boolean intention. The first two can be easily provided on older perls, but polyfilling this latter function is not possible, because the question of "does this value have boolean intention?" is not a meaningful question to ask on such perls. There are a number of possible ways to handle this situation:
 -->
 
 * 1. シンボルのインポートを拒否する。 例えば、`use builtin 'isbool'`は、コンパイル時に失敗する
@@ -386,10 +386,10 @@ For example, RFC 0008 proposes adding new functions `true` and `false` to provid
 3. Give a meaningful but inaccurate answer - `isbool $x` would always return false, as the concept of "boolean intention" does not exist here
 -->
 
-それぞれ正しい振る舞いだと主張できます。このRFCが、この問いに直接回答する必要はありませんが、少なくとも追加されるポリフィル関数はこういった問題が認められており、全てのポリフィル関数はこの問題に関して可能な限り一貫した振る舞いになることが望まれるでしょう。
+それぞれ正しい振る舞いだと主張できます。このPPCが、この問いに直接回答する必要はありませんが、少なくとも追加されるポリフィル関数はこういった問題が認められており、全てのポリフィル関数はこの問題に関して可能な限り一貫した振る舞いになることが望まれるでしょう。
 
 <!-- original
-Each of these could be argued as the correct behaviour. While it is not directly a question this RFC needs to answer, it is at least acknowledged that some added polyfill functions would have this question, and it would be encouraged that all polyfilled functions should attempt to act as consistently as reasonably possible in this regard.
+Each of these could be argued as the correct behaviour. While it is not directly a question this PPC needs to answer, it is at least acknowledged that some added polyfill functions would have this question, and it would be encouraged that all polyfilled functions should attempt to act as consistently as reasonably possible in this regard.
 -->
 
 ## Copyright

--- a/docs/articles/github.com/Perl/PPCs/ppcs/ppc0011-slurp-argument.md
+++ b/docs/articles/github.com/Perl/PPCs/ppcs/ppc0011-slurp-argument.md
@@ -1,6 +1,6 @@
-# Perl/RFCs/rfcs/rfc0011 Command-line flag for slurping の翻訳
+# Perl/PPCs/ppcs/ppc0011 Command-line flag for slurping の翻訳
 
-この文書は、[Perl/RFCs/rfcs/rfc0011](https://github.com/Perl/RFCs/blob/main/rfcs/rfc0011.md)を翻訳したものです。
+この文書は、[Perl/PPCs/ppcs/ppc0011-slurp-argument](https://github.com/Perl/PPCs/blob/main/ppcs/ppc0011-slurp-argument.md)を翻訳したものです。
 
 原題は「Command-line flag for slurping」です。
 
@@ -114,14 +114,14 @@ Hopefully none.
 
 （採用しなかった案）
 
-- `--slurp` という長いフラグはPerlがいまはサポートせず、この RFC の範囲外です。
+- `--slurp` という長いフラグはPerlがいまはサポートせず、この PPC の範囲外です。
 
 - `-R`, `-o` という `-g` より良さそうな別の文字も採用しませんでした。
   残念ながら、もっとも自然な選択だと思われる `-s` は[すでに使われています](https://perldoc.perl.org/5.34.0/perlrun#-s)。
 
 <!-- original
 - Long flag, e.g. `--slurp`. Perl currently doesn't support long flags and
-  adding them would be beyond the scope of this RFC.
+  adding them would be beyond the scope of this PPC.
 
 - Alternative spellings of the flag, e.g. `-R`, `-o`. The author believes none
   of them are better or worse than `-g`. Unfortunately, the most natural choice,


### PR DESCRIPTION
Ref: https://github.com/Perl/PPCs/pull/35

次を行いました
- `perl -i -pe 's/RFC/PPC/g' docs/articles/github.com/Perl/PPCs/**/*.md`
- `perl -i -pe 's/rfc/ppc/g' docs/articles/github.com/Perl/PPCs/**/*.md`
- オリジナルのファイル名が変更されていたので、追従しました。(e.g. rfc0001.md -> ppc0001-n-at-a-time-for.md)